### PR TITLE
Fix S3 connection error

### DIFF
--- a/vaporfile/s3_util.py
+++ b/vaporfile/s3_util.py
@@ -1,4 +1,4 @@
-from boto.s3.connection import S3Connection
+from boto.s3.connection import OrdinaryCallingFormat, S3Connection
 from boto.exception import S3ResponseError
 
 import config
@@ -11,7 +11,8 @@ def get_connection():
     global __conn
     if not __conn:
         __conn = S3Connection(c["credentials"]["access_key"],
-                              c["credentials"]["secret_key"])
+                              c["credentials"]["secret_key"],
+                              calling_format=OrdinaryCallingFormat())
     return __conn
 
 def get_bucket_names(conn):


### PR DESCRIPTION
This fixes the error

```
CertificateError: hostname ‘ourcompany.images.s3.amazonaws.com’ doesn't match either of '*.s3.amazonaws.com', 's3.amazonaws.com'
```

I don’t expect this to be merged, but I thought people wanting to update their old S3/CloudFront sites might want to know, especially now that SSL is available for free. :)

Thanks for all the work going into this. Got nostalgic revisiting my project to enable SSL.
